### PR TITLE
Canonical disagrees with redirect

### DIFF
--- a/source/_includes/head.html
+++ b/source/_includes/head.html
@@ -16,7 +16,7 @@
   <meta name="MobileOptimized" content="320">
   <meta name="viewport" content="width=device-width, initial-scale=1">
 
-  {% capture canonical %}{{ site.url }}{% if site.permalink contains '.html' %}{{ page.url }}{% else %}{{ page.url | remove:'index.html' | strip_slash }}{% endif %}{% endcapture %}
+  {% capture canonical %}{{ site.url }}{% if site.permalink contains '.html' %}{{ page.url }}{% else %}{{ page.url | remove:'index.html' }}{% endif %}{% endcapture %}
   <link rel="canonical" href="{{ canonical }}">
   <link href="{{ root_url }}/favicon.png" rel="icon">
   <link href="{{ root_url }}/stylesheets/screen.css" media="screen, projection" rel="stylesheet" type="text/css">


### PR DESCRIPTION
Your redirects redirect a plain page to one with a trailing slash, but the canonical inconsistently indicated with page without the slash is the primary. 

See http://paul.kinlan.me/this-is-the-web-platform/ vs http://paul.kinlan.me/this-is-the-web-platform

cc @adewale
