### PR TITLE
Simplify code snippet further

### DIFF
--- a/content/en/2020-06-11-shiminig-request-formdata-in-safari.markdown
+++ b/content/en/2020-06-11-shiminig-request-formdata-in-safari.markdown
@@ -17,7 +17,7 @@ I wrote a little shim that hack together a similar looking API to the `FormData`
 ```JavaScript
 export default async (request) => {
   const data = await request.text();
-  const params = new URLSearchParams(decoder.decode(data));
+  const params = new URLSearchParams(data);
 
   return params;
 };

--- a/content/en/2020-06-11-shiminig-request-formdata-in-safari.markdown
+++ b/content/en/2020-06-11-shiminig-request-formdata-in-safari.markdown
@@ -16,9 +16,8 @@ I wrote a little shim that hack together a similar looking API to the `FormData`
 
 ```JavaScript
 export default async (request) => {
-  const data = await request.arrayBuffer();
-  const decoder = new TextDecoder("utf-8")
-  const params = new URLSearchParams(`?${decoder.decode(data)}`);
+  const data = await request.text();
+  const params = new URLSearchParams(decoder.decode(data));
 
   return params;
 };


### PR DESCRIPTION
 - You can get decoded text directly from Request.
 - `?` is simply ignored by `URLSearchParams`, so you don't need to pass it if it's not present in your string in the first place.