### PR TITLE
Check for correct content type

### DIFF
--- a/content/en/2020-06-11-shiminig-request-formdata-in-safari.markdown
+++ b/content/en/2020-06-11-shiminig-request-formdata-in-safari.markdown
@@ -16,6 +16,10 @@ I wrote a little shim that hack together a similar looking API to the `FormData`
 
 ```JavaScript
 export default async (request) => {
+  if (request.headers.get('content-type') !== 'application/x-www-form-urlencoded') {
+    return null;
+  }
+
   const data = await request.text();
   const params = new URLSearchParams(data);
 


### PR DESCRIPTION
Instead of just mentioning it in the post, might as well put in an explicit check on the `Content-Type` header (just in case people start using this copied-and-pasted as a polyfill).