### PR TITLE
2022-12-03-web-follow: Fix double escaped title quotes

### DIFF
--- a/content/2022-12-03-web-follow.md
+++ b/content/2022-12-03-web-follow.md
@@ -19,7 +19,7 @@ tags:
 - user experience
 - cross-instance following
 - app integration
-title: Thoughts on a \"Web Follow\" protocol
+title: Thoughts on a "Web Follow" protocol
 ---
 
 I've been digging Mastodon for the past couple of weeks. It's fun and it's incredible to see how polished the web app is. It's an exemplar of what is possible in the browser. Kudos.


### PR DESCRIPTION
https://paul.kinlan.me/thoughts-on-web-follow/

YAML takes either quoted `"foo \"Bar\" baz"` or bare unquoted `foo "Bar" baz`.

Ref https://github.com/PaulKinlan/paul.kinlan.me/commit/f79bc88227dda78826f2a25ff37fc12dd55c2d6b